### PR TITLE
Create `test` and `lint` Workflows

### DIFF
--- a/.github/workflows/lint.workflow.yml
+++ b/.github/workflows/lint.workflow.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:    
+      - '*'
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run lint
+      run: npm run lint

--- a/.github/workflows/lint.workflow.yml
+++ b/.github/workflows/lint.workflow.yml
@@ -1,17 +1,24 @@
 on:
   push:
-    branches:    
-      - '*'
+    branches-ignore:    
+      - master
+      - gh-pages
+
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Set up Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+
     - name: Checkout repo
       uses: actions/checkout@v2
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci 
 
     - name: Run lint
       run: npm run lint

--- a/.github/workflows/lint.workflow.yml
+++ b/.github/workflows/lint.workflow.yml
@@ -22,3 +22,4 @@ jobs:
 
     - name: Run lint
       run: npm run lint
+      

--- a/.github/workflows/lint.workflow.yml
+++ b/.github/workflows/lint.workflow.yml
@@ -22,4 +22,3 @@ jobs:
 
     - name: Run lint
       run: npm run lint
-      

--- a/.github/workflows/lint.workflow.yml
+++ b/.github/workflows/lint.workflow.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
     - name: Set up Node
       uses: actions/setup-node@v3
       with:
         node-version: 18.x
-
-    - name: Checkout repo
-      uses: actions/checkout@v2
 
     - name: Install dependencies
       run: npm ci 

--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -22,3 +22,4 @@ jobs:
 
     - name: Run tests
       run: npm run test
+      

--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:    
+      - '*'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm run test

--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -1,17 +1,24 @@
 on:
   push:
-    branches:    
-      - '*'
+    branches-ignore:    
+      - master
+      - gh-pages
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Set up Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+
     - name: Checkout repo
       uses: actions/checkout@v2
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci 
 
     - name: Run tests
       run: npm run test

--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -9,17 +9,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
     - name: Set up Node
       uses: actions/setup-node@v3
       with:
         node-version: 18.x
-
-    - name: Checkout repo
-      uses: actions/checkout@v2
 
     - name: Install dependencies
       run: npm ci 
 
     - name: Run tests
       run: npm run test
-      


### PR DESCRIPTION
This PR adds two workflows, one for linting and one for testing. Testing workflow should be disabled until tests are added, otherwise it will yield an error due to the lack of a `test` script in `package.json`