### PR TITLE
feature: Configure global theme (font/colors)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,25 +3,20 @@
 @tailwind utilities;
 
 :root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
+  --theme-color-primary: #057CDE;
+  --theme-color-secondary: #035496;
+  --theme-color-accent: #59B1F9;
+  --theme-color-text: white;
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
+  --background-gradiant-light: #004278;
+  --background-gradiant-dark: #030304;
 }
 
 body {
-  color: rgb(var(--foreground-rgb));
+  color: var(--theme-color-text);
   background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+    to bottom right,
+    var(--background-gradiant-dark),
+    var(--background-gradiant-light)
+  )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,11 @@
 import "./globals.css";
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Poppins } from "next/font/google";
 
-const inter = Inter({ subsets: ["latin"] });
+const font = Poppins({
+  weight: ['400', '700'],
+  subsets: ["latin"],
+});
 
 export const metadata: Metadata = {
   title: "Society of Software Developers",
@@ -16,7 +19,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={font.className}>{children}</body>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
 
 const font = Poppins({
-  weight: ['400', '700'],
+  weight: ["400", "700"],
   subsets: ["latin"],
 });
 


### PR DESCRIPTION
Resolves #6. This configures the global theme (font = `Poppins`, colors matching our slide decks). As best I can tell, it's not feasible to use `prefers-color-scheme: light` as a 'dark mode by default' feature since `light` is the default value (as opposed to strictly being an opt-in preference). Could be something to revisit later; for now will remove the media query but keep the CSS variable setup for future use.

![image](https://github.com/ufssd/ufssd-website/assets/35618116/82c5ee21-64e5-4b05-adbe-e7ca0124e7df)
