### PR TITLE
Fix eslint-config-next version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint": "^8.52.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.1.0",
-    "eslint-config-next": "^13.5.4",
+    "eslint-config-next": "^13.5.6",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-unicorn": "^48.0.1",


### PR DESCRIPTION
This version was missed in #24. The version pinned in `package-lock.json` is correct (`^13.5.6`), so this discrepancy causes writes to `package-lock.json` when running `npm install`.