### PR TITLE
Chores: Update node version to 20.8.9

### DIFF
--- a/.github/workflows/lint.workflow.yml
+++ b/.github/workflows/lint.workflow.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Install dependencies
       run: npm ci 

--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Install dependencies
       run: npm ci 

--- a/.nprmc
+++ b/.nprmc
@@ -1,0 +1,2 @@
+# .npmrc
+engine-strict=true

--- a/.nprmc
+++ b/.nprmc
@@ -1,2 +1,0 @@
-# .npmrc
-engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,9 @@
         "postcss": "^8.4.31",
         "tailwindcss": "^3.3.5",
         "typescript": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=19.0.0 <=20.8.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=19.0.0 <=20.8.9"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "ufssd-website",
   "version": "0.1.0",
   "private": true,
+  "engines" : {
+    "node" : ">=20.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -31,8 +34,5 @@
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
     "typescript": "^5.2.2"
-  },
-  "engines" : {
-    "node" : ">=19.0.0 <=20.8.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines" : {
-    "node" : ">=20.0.0"
+    "node" : "^20.0.0"
   },
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
     "typescript": "^5.2.2"
+  },
+  "engines" : {
+    "node" : ">=19.0.0 <=20.8.9"
   }
 }


### PR DESCRIPTION
Updated node version to 20.8.9, made it so lint and test would both use this higher version, created .nprmc to enforce the use of this higher version. Simple dependency bump.