### PR TITLE
Chore: Change semester on landing page to 'Spring 2024'

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ export default function Home() {
           systems and better prepare members for team projects, internships, and
           careers in software development.
         </p>
-        <h2>Fall 2023 Meetings</h2>
+        <h2>Spring 2024 Meetings</h2>
         <p>Tuesday, 6:15pm in CISE A101 and over Zoom</p>
         <ImageCarousel />
       </main>


### PR DESCRIPTION
Changes the semester on the landing page from 'Fall 2023' to 'Spring 2024' to reflect the current semester.

![image](https://github.com/ufssd/ufssd-website/assets/92892499/6b21a0da-e1e9-4569-a0c3-8ab6a1341539)
